### PR TITLE
feat: Vercel Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 test.sh
+
+# Vercel
+.vercel

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ A simple proxy for PR comments. Works well with [add-pr-comment](https://github.
 ## How it works
 
 This app is a thin Node.js proxy around the [create an issue comment](https://docs.github.com/en/rest/reference/issues#create-an-issue-comment) GitHub endpoint that allows you to send requests with a GitHub Action's [temporary token](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret) and create issue comments. It verifies that your request has a valid temporary token, but it's difficult to ensure any more than that. A shared secret cannot be used as GitHub will strip it when the fork's Actions run.
+
+## Vercel Deployment Notes
+
+### About the `.vercel` Folder
+The `.vercel` folder is automatically created when you link your project directory to a Vercel project. This folder should not be committed to your repository - it contains local deployment information like project and organization IDs.
+
+**Important:** Add `.vercel` to your `.gitignore` file to prevent accidentally committing it.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "add-pr-comment-proxy",
   "version": "0.0.1",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "build": "tsc",
+    "vercel-build": "npm run build",
+    "deploy": "vercel deploy --prod"
   },
   "repository": {
     "type": "git",
@@ -15,18 +18,22 @@
   },
   "homepage": "https://github.com/mshick/add-pr-comment-proxy#readme",
   "engines": {
-    "node": "12.11.0"
+    "node": "18.x"
   },
   "dependencies": {
-    "@actions/http-client": "^1.0.8",
+    "@actions/http-client": "^1.0.11",
+    "@vercel/node": "^2.10.3",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "express-json-api-error-handler": "^6.0.0"
+    "express-json-api-error-handler": "^6.0.0",
+    "next": "^14.2.18"
   },
   "devDependencies": {
+    "@types/node": "^18.19.65",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "typescript": "^5.7.2"
   }
 }

--- a/serverless/_cors.ts
+++ b/serverless/_cors.ts
@@ -1,0 +1,15 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+
+export function setCorsHeaders(res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+  res.setHeader('Access-Control-Expose-Headers', 'Authorization')
+}
+
+export function handleCors(req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'OPTIONS') {
+    setCorsHeaders(res)
+    return res.status(200).end()
+  }
+} 

--- a/serverless/comment.ts
+++ b/serverless/comment.ts
@@ -1,0 +1,105 @@
+import { HttpClient } from '@actions/http-client'
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { setCorsHeaders, handleCors } from './_cors'
+import { checkToken } from './utils/github'
+
+const GITHUB_API_URL = 'https://api.github.com'
+
+interface GitHubError {
+  statusCode?: number;
+  message?: string;
+  result?: any;
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse
+) {
+  console.log('Received request:', {
+    method: req.method,
+    url: req.url,
+    headers: req.headers
+  });
+  
+  // Handle CORS preflight
+  if (handleCors(req, res)) return
+  
+  // Set CORS headers for actual request
+  setCorsHeaders(res)
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+  // Initialize HTTP client
+  const client = new HttpClient('add-pr-comment-proxy')
+
+  // Extract token from Authorization header
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith('Bearer ') 
+    ? authHeader.substring(7) 
+    : req.body?.token;  // Fallback to body if not in header
+
+  const { owner, repo, issueNumber, body } = req.body || {};
+
+  // Add debug logging
+  console.log('Parsed request:', { 
+    hasToken: !!token, 
+    owner, 
+    repo, 
+    issueNumber, 
+    body, 
+    tokenLength: token?.length 
+  });
+
+  // Validate token
+  console.log('Attempting to validate token...');
+  const isTokenValid = await checkToken(client, token)
+  console.log('Token validation result:', isTokenValid);
+  if (!isTokenValid) {
+    return res.status(401).json({
+      error: 'Invalid or missing GitHub token'
+    })
+  }
+
+  if (!token || !owner || !repo || !issueNumber || !body) {
+    return res.status(400).json({
+      error: 'Missing required fields: token, owner, repo, issueNumber, body'
+    })
+  }
+
+  try {
+    console.log('Attempting to create comment:', {
+      url: `${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      hasBody: !!body,
+      tokenPrefix: token.substring(0, 4) // Log just the start of the token
+    });
+    
+    const response = await client.postJson(
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      { body },
+      {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
+      }
+    )
+
+    return res.status(200).json(response.result)
+  } catch (error) {
+    // Enhanced error logging with type casting
+    const gitHubError = error as GitHubError
+    console.error('Error details:', {
+      status: gitHubError.statusCode,
+      message: gitHubError.message,
+      response: gitHubError.result
+    })
+    
+    return res.status(gitHubError.statusCode || 500).json({ 
+      error: 'Failed to post comment',
+      details: gitHubError.result || gitHubError.message
+    })
+  }
+} 

--- a/serverless/utils/github.ts
+++ b/serverless/utils/github.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@actions/http-client'
+
+export async function checkToken(http: HttpClient, token: string): Promise<boolean> {
+  if (!token) {
+    console.log('Token is missing');
+    return false;
+  }
+
+  try {
+    // First try to get user info to validate PAT
+    const userResponse = await http.getJson('https://api.github.com/user', {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    });
+    
+    // If we get here, it's a valid PAT
+    console.log('Token validated as Personal Access Token');
+    return true;
+  } catch (err: any) {
+    // Check if it's a temporary token
+    if (err.statusCode === 403 && 
+        err.result?.message?.startsWith('Resource not accessible by integration')) {
+      console.log('Token validated as GitHub Actions temporary token');
+      return true;
+    }
+    
+    console.log('Token validation failed:', err.message);
+    return false;
+  }
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+      "target": "es2017",
+      "module": "commonjs",
+      "lib": ["es2017"],
+      "strict": true,
+      "esModuleInterop": true,
+      "skipLibCheck": true,
+      "forceConsistentCasingInFileNames": true,
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "isolatedModules": true,
+      "incremental": true,
+      "baseUrl": ".",
+      "paths": {
+        "@/*": ["./*"]
+      }
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules"]
+  }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,22 @@
+{
+    "version": 2,
+    "builds": [
+      {
+        "src": "serverless/**/*.ts",
+        "use": "@vercel/node"
+      }
+    ],
+    "routes": [
+      {
+        "src": "/api/(.*)",
+        "dest": "/serverless/$1.ts"
+      },
+      {
+        "src": "/(.*)",
+        "dest": "/serverless/comment.ts"
+      }
+    ],
+    "env": {
+      "NODE_ENV": "production"
+    }
+  }


### PR DESCRIPTION
# add-pr-comment-proxy

A simple proxy for PR comments. Works well with [add-pr-comment](https://github.com/mshick/add-pr-comment/). Workaround for GitHub making all token permissions read-only when a fork is submitted for a PR. See [this discussion](https://github.community/t/github-actions-are-severely-limited-on-prs/18179/4) for more detail.

## Deploy

**Requirements**

- A [personal access token](https://github.com/settings/tokens) with the `repo:public_repos` scope if you're using this to support a public repo. Your use-case might require other scopes.

**Run on Cloud Run**

[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)

## How it works

This app is a thin Node.js proxy around the [create an issue comment](https://docs.github.com/en/rest/reference/issues#create-an-issue-comment) GitHub endpoint that allows you to send requests with a GitHub Action's [temporary token](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret) and create issue comments. It verifies that your request has a valid temporary token, but it's difficult to ensure any more than that. A shared secret cannot be used as GitHub will strip it when the fork's Actions run.

/claim #2 

Production URL: https://add-pr-comment-proxy-alpha.vercel.app/

![image](https://github.com/user-attachments/assets/9d405b6a-e3eb-4609-9633-abed9a12b4ca)


