### PR TITLE
Fixed: Edit existing comment rather than reposting

### DIFF
--- a/pages/api/repos/[owner]/[repo]/issues/[issueNumber]/comments.js
+++ b/pages/api/repos/[owner]/[repo]/issues/[issueNumber]/comments.js
@@ -1,16 +1,44 @@
 import { HttpClient } from '@actions/http-client'
 
-const createComment = async (http, params) => {
+const createOrUpdateComment = async (http, params) => {
   const { repoToken, owner, repo, issueNumber, body } = params
 
-  return http.postJson(
+  // Fetch existing comments
+  const commentsResponse = await http.getJson(
     `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
-    { body },
     {
       accept: 'application/vnd.github.v3+json',
       authorization: `token ${repoToken}`,
     }
   )
+
+  // Check if a comment already exists
+  const existingComment = commentsResponse.result.find(comment =>
+    comment.user.login === "tscircuitbot"
+  )
+
+
+  if (existingComment) {
+    // Update the existing comment
+    return http.patchJson(
+      `https://api.github.com/repos/${owner}/${repo}/issues/comments/${existingComment.id}`,
+      { body },
+      {
+        accept: 'application/vnd.github.v3+json',
+        authorization: `token ${repoToken}`,
+      }
+    )
+  } else {
+    // Create a new comment if no existing one is found
+    return http.postJson(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      { body },
+      {
+        accept: 'application/vnd.github.v3+json',
+        authorization: `token ${repoToken}`,
+      }
+    )
+  }
 }
 
 const checkToken = async (http, token) => {
@@ -54,7 +82,7 @@ export default async function handler(req, res) {
     }
 
     const { owner, repo, issueNumber } = req.query
-    const response = await createComment(httpClient, {
+    const response = await createOrUpdateComment(httpClient, {
       owner,
       repo,
       issueNumber,


### PR DESCRIPTION
/claim #7


I think there is a syntax issue in the workflow file in the core repo(although I was the one who contributed to that file, which was working fine earlier, now it's giving issues). You can see this pr on my forked repo(fixed workflow file well): [https://github.com/MustafaMulla29/core/pull/7](https://github.com/tscircuit/add-pr-comment-proxy/issues/url)

And I tried running the workflow with and without proxy, with proxy it wasn't updating the comment instead it was creating a new comment and without proxy it was successfully updating the existing comment.

I think the issue is in the add-pr-comment-proxy, where you are only creating a new comment and not checking for existing comment.

this is the video of the requests i made with the updated code(checking for an existing comment and updating it):



https://github.com/user-attachments/assets/59a8f698-d87d-4afd-8126-a7f2056b3248

